### PR TITLE
Enable the ability to subscribe to multiple notify characteristics at once

### DIFF
--- a/src/android/TNS_BluetoothGattCallback.ts
+++ b/src/android/TNS_BluetoothGattCallback.ts
@@ -29,10 +29,7 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
     if (newState === android.bluetooth.BluetoothProfile.STATE_CONNECTED && status === android.bluetooth.BluetoothGatt.GATT_SUCCESS) {
       this.select2MPHY(gatt);
     } else {
-      CLog(
-        CLogTypes.info,
-        `TNS_BluetoothGattCallback.onConnectionStateChange ---- disconnecting the gatt: ${gatt} ----`
-      );
+      CLog(CLogTypes.info, `TNS_BluetoothGattCallback.onConnectionStateChange ---- disconnecting the gatt: ${gatt} ----`);
       // perhaps the device was manually disconnected, or in use by another device
       this.owner.get().gattDisconnect(gatt);
     }
@@ -44,10 +41,7 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
    * @param status [number] - GATT_SUCCESS if the remote device has been explored successfully.
    */
   onServicesDiscovered(gatt: android.bluetooth.BluetoothGatt, status: number) {
-    CLog(
-      CLogTypes.info,
-      `TNS_BluetoothGattCallback.onServicesDiscovered ---- gatt: ${gatt}, status (0=success): ${status}`
-    );
+    CLog(CLogTypes.info, `TNS_BluetoothGattCallback.onServicesDiscovered ---- gatt: ${gatt}, status (0=success): ${status}`);
 
     if (status === android.bluetooth.BluetoothGatt.GATT_SUCCESS) {
       // TODO grab from cached object and extend with services data?
@@ -84,10 +78,7 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
               };
             }
 
-            CLog(
-              CLogTypes.info,
-              `TNS_BluetoothGattCallback.onServicesDiscovered ---- pushing descriptor: ${descriptor}`
-            );
+            CLog(CLogTypes.info, `TNS_BluetoothGattCallback.onServicesDiscovered ---- pushing descriptor: ${descriptor}`);
             descriptorsJs.push(descriptorJs);
           }
 
@@ -123,10 +114,7 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
             };
           }
 
-          CLog(
-            CLogTypes.info,
-            `TNS_BluetoothGattCallback.onServicesDiscovered ---- pushing characteristic: ${characteristicJs}`
-          );
+          CLog(CLogTypes.info, `TNS_BluetoothGattCallback.onServicesDiscovered ---- pushing characteristic: ${characteristicJs}`);
           characteristicsJs.push(characteristicJs);
         }
 
@@ -184,10 +172,7 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
    * @param gatt [android.bluetooth.BluetoothGatt] - GATT client the characteristic is associated with.
    * @param characteristic [android.bluetooth.BluetoothGattCharacteristic] - Characteristic that has been updated as a result of a remote notification event.
    */
-  onCharacteristicChanged(
-    gatt: android.bluetooth.BluetoothGatt,
-    characteristic: android.bluetooth.BluetoothGattCharacteristic
-  ) {
+  onCharacteristicChanged(gatt: android.bluetooth.BluetoothGatt, characteristic: android.bluetooth.BluetoothGattCharacteristic) {
     const device = gatt.getDevice();
     CLog(
       CLogTypes.info,
@@ -249,15 +234,8 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
    * @param descriptor - Descriptor that was read from the associated remote device.
    * @param status - GATT_SUCCESS if the read operation was completed successfully
    */
-  onDescriptorRead(
-    gatt: android.bluetooth.BluetoothGatt,
-    descriptor: android.bluetooth.BluetoothGattDescriptor,
-    status: number
-  ) {
-    CLog(
-      CLogTypes.info,
-      `TNS_BluetoothGattCallback.onDescriptorRead ---- gatt: ${gatt}, descriptor: ${descriptor}, status: ${status}`
-    );
+  onDescriptorRead(gatt: android.bluetooth.BluetoothGatt, descriptor: android.bluetooth.BluetoothGattDescriptor, status: number) {
+    CLog(CLogTypes.info, `TNS_BluetoothGattCallback.onDescriptorRead ---- gatt: ${gatt}, descriptor: ${descriptor}, status: ${status}`);
   }
 
   /**
@@ -304,10 +282,7 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
    * @param status - GATT_SUCCESS if the RSSI was read successfully.
    */
   onReadRemoteRssi(gatt: android.bluetooth.BluetoothGatt, rssi: number, status: number) {
-    CLog(
-      CLogTypes.info,
-      `TNS_BluetoothGattCallback.onReadRemoteRssi ---- gatt: ${gatt} rssi: ${rssi}, status: ${status}`
-    );
+    CLog(CLogTypes.info, `TNS_BluetoothGattCallback.onReadRemoteRssi ---- gatt: ${gatt} rssi: ${rssi}, status: ${status}`);
   }
 
   private select2MPHY(gatt: android.bluetooth.BluetoothGatt) {

--- a/src/android/TNS_BluetoothGattCallback.ts
+++ b/src/android/TNS_BluetoothGattCallback.ts
@@ -162,7 +162,9 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
       stateObject.onReadPromise({
         valueRaw: value,
         value: this.owner.get().decodeValue(value),
-        characteristicUUID: characteristic.getUuid()
+        peripheralUUID: gatt.getDevice().getAddress(),
+        serviceUUID: this.owner.get().uuidToString(characteristic.getService().getUuid()),
+        characteristicUUID: this.owner.get().uuidToString(characteristic.getUuid())
       });
     }
   }
@@ -190,7 +192,9 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
       stateObject.onNotifyCallback({
         valueRaw: value,
         value: this.owner.get().decodeValue(value),
-        characteristicUUID: characteristic.getUuid()
+        peripheralUUID: gatt.getDevice().getAddress(),
+        serviceUUID: this.owner.get().uuidToString(characteristic.getService().getUuid()),
+        characteristicUUID: this.owner.get().uuidToString(characteristic.getUuid())
       });
     }
   }
@@ -223,7 +227,9 @@ export class TNS_BluetoothGattCallback extends android.bluetooth.BluetoothGattCa
 
     if (stateObject.onWritePromise) {
       stateObject.onWritePromise({
-        characteristicUUID: characteristic.getUuid()
+        peripheralUUID: gatt.getDevice().getAddress(),
+        serviceUUID: this.owner.get().uuidToString(characteristic.getService().getUuid()),
+        characteristicUUID: this.owner.get().uuidToString(characteristic.getUuid())
       });
     }
   }

--- a/src/common.ts
+++ b/src/common.ts
@@ -375,10 +375,9 @@ export interface StartNotifyingOptions extends CRUDOptions {
 /**
  * Response object for the read function
  */
-export interface ReadResult {
+export interface ReadResult extends CRUDOptions {
   value: any;
   valueRaw: any;
-  characteristicUUID: string;
 }
 
 export interface StartAdvertisingOptions {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -282,10 +282,9 @@ export interface StartNotifyingOptions extends CRUDOptions {
 /**
  * Response object for the read function
  */
-export interface ReadResult {
+export interface ReadResult extends CRUDOptions {
   value: any;
   valueRaw: any;
-  characteristicUUID: string;
 }
 
 export interface StartAdvertisingOptions {

--- a/src/ios/CBCentralManagerDelegateImpl.ts
+++ b/src/ios/CBCentralManagerDelegateImpl.ts
@@ -40,20 +40,14 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
 
     // find the peri in the array and attach the delegate to that
     const peri = this._owner.get().findPeripheral(peripheral.identifier.UUIDString);
-    CLog(
-      CLogTypes.info,
-      `----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral: cached perio: ${peri}`
-    );
+    CLog(CLogTypes.info, `----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral: cached perio: ${peri}`);
 
     const cb = this._owner.get()._connectCallbacks[peripheral.identifier.UUIDString];
     const delegate = CBCentralManagerDelegateImpl.new().initWithCallback(this._owner, cb);
     CFRetain(delegate);
     peri.delegate = delegate;
 
-    CLog(
-      CLogTypes.info,
-      "----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral, let's discover service"
-    );
+    CLog(CLogTypes.info, "----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral, let's discover service");
     peri.discoverServices(null);
   }
 
@@ -67,11 +61,7 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
    * @param peripheral [CBPeripheral] - The peripheral that has been disconnected.
    * @param error? [NSError] - If an error occurred, the cause of the failure.
    */
-  public centralManagerDidDisconnectPeripheralError(
-    central: CBCentralManager,
-    peripheral: CBPeripheral,
-    error?: NSError
-  ) {
+  public centralManagerDidDisconnectPeripheralError(central: CBCentralManager, peripheral: CBPeripheral, error?: NSError) {
     // this event needs to be honored by the client as any action afterwards crashes the app
     const cb = this._owner.get()._disconnectCallbacks[peripheral.identifier.UUIDString];
     if (cb) {
@@ -94,18 +84,8 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
    * @param peripheral [CBPeripheral] - The peripheral that failed to connect.
    * @param error? [NSError] - The cause of the failure.
    */
-  public centralManagerDidFailToConnectPeripheralError(
-    central: CBCentralManager,
-    peripheral: CBPeripheral,
-    error?: NSError
-  ) {
-    CLog(
-      CLogTypes.info,
-      `CBCentralManagerDelegate.centralManagerDidFailToConnectPeripheralError ----`,
-      central,
-      peripheral,
-      error
-    );
+  public centralManagerDidFailToConnectPeripheralError(central: CBCentralManager, peripheral: CBPeripheral, error?: NSError) {
+    CLog(CLogTypes.info, `CBCentralManagerDelegate.centralManagerDidFailToConnectPeripheralError ----`, central, peripheral, error);
   }
 
   /**
@@ -126,9 +106,7 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
   ) {
     CLog(
       CLogTypes.info,
-      `CBCentralManagerDelegateImpl.centralManagerDidDiscoverPeripheralAdvertisementDataRSSI ---- ${
-        peripheral.name
-      } @ ${RSSI}`
+      `CBCentralManagerDelegateImpl.centralManagerDidDiscoverPeripheralAdvertisementDataRSSI ---- ${peripheral.name} @ ${RSSI}`
     );
     const peri = this._owner.get().findPeripheral(peripheral.identifier.UUIDString);
     if (!peri) {
@@ -139,18 +117,14 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
         if (advData.objectForKey(CBAdvertisementDataManufacturerDataKey)) {
           const manufacturerIdBuffer = this._owner
             .get()
-            .toArrayBuffer(
-              advData.objectForKey(CBAdvertisementDataManufacturerDataKey).subdataWithRange(NSMakeRange(0, 2))
-            );
+            .toArrayBuffer(advData.objectForKey(CBAdvertisementDataManufacturerDataKey).subdataWithRange(NSMakeRange(0, 2)));
           manufacturerId = new DataView(manufacturerIdBuffer, 0).getUint16(0, true);
           manufacturerData = this._owner
             .get()
             .toArrayBuffer(
               advData
                 .objectForKey(CBAdvertisementDataManufacturerDataKey)
-                .subdataWithRange(
-                  NSMakeRange(2, advData.objectForKey(CBAdvertisementDataManufacturerDataKey).length - 2)
-                )
+                .subdataWithRange(NSMakeRange(2, advData.objectForKey(CBAdvertisementDataManufacturerDataKey).length - 2))
             );
         }
 
@@ -198,9 +172,6 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
    * @link - https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/central_manager_state_restoration_options
    */
   public centralManagerWillRestoreState(central: CBCentralManager, dict: NSDictionary<string, any>) {
-    CLog(
-      CLogTypes.info,
-      `CBCentralManagerDelegateImpl.centralManagerWillRestoreState ---- central: ${central}, dict: ${dict}`
-    );
+    CLog(CLogTypes.info, `CBCentralManagerDelegateImpl.centralManagerWillRestoreState ---- central: ${central}, dict: ${dict}`);
   }
 }

--- a/src/ios/CBCentralManagerDelegateImpl.ts
+++ b/src/ios/CBCentralManagerDelegateImpl.ts
@@ -3,6 +3,7 @@ declare var NSMakeRange; // not recognized by platform-declarations
 
 import { CLog, CLogTypes } from '../common';
 import { Bluetooth } from './ios_main';
+import { CBPeripheralDelegateImpl } from './CBPeripheralDelegateImpl';
 
 /**
  * @link - https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate
@@ -43,7 +44,7 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
     CLog(CLogTypes.info, `----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral: cached perio: ${peri}`);
 
     const cb = this._owner.get()._connectCallbacks[peripheral.identifier.UUIDString];
-    const delegate = CBCentralManagerDelegateImpl.new().initWithCallback(this._owner, cb);
+    const delegate = CBPeripheralDelegateImpl.new().initWithCallback(this._owner, cb);
     CFRetain(delegate);
     peri.delegate = delegate;
 

--- a/src/ios/CBPeripheralDelegateImpl.ts
+++ b/src/ios/CBPeripheralDelegateImpl.ts
@@ -192,6 +192,8 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
 
     const result = {
       type: characteristic.isNotifying ? 'notification' : 'read',
+      peripheralUUID: peripheral.identifier.UUIDString,
+      serviceUUID: characteristic.service.UUID.UUIDString,
       characteristicUUID: characteristic.UUID.UUIDString,
       valueRaw: characteristic.value,
       value: this._owner.get().toArrayBuffer(characteristic.value)
@@ -232,6 +234,8 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
     );
     if (this._onWritePromise) {
       this._onWritePromise({
+        peripheralUUID: peripheral.identifier.UUIDString,
+        serviceUUID: characteristic.service.UUID.UUIDString,
         characteristicUUID: characteristic.UUID.UUIDString
       });
     } else {

--- a/src/ios/CBPeripheralDelegateImpl.ts
+++ b/src/ios/CBPeripheralDelegateImpl.ts
@@ -41,10 +41,7 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
    * @param error [NSError] - If an error occurred, the cause of the failure.
    */
   public peripheralDidDiscoverServices(peripheral: CBPeripheral, error?: NSError) {
-    CLog(
-      CLogTypes.info,
-      `CBPeripheralDelegateImpl.peripheralDidDiscoverServices ---- peripheral: ${peripheral}, ${error}`
-    );
+    CLog(CLogTypes.info, `CBPeripheralDelegateImpl.peripheralDidDiscoverServices ---- peripheral: ${peripheral}, ${error}`);
     // map native services to a JS object
     this._services = [];
     for (let i = 0; i < peripheral.services.count; i++) {
@@ -64,11 +61,7 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
    * @param service [CBService] - The CBService object containing the included service.
    * @param error [NSError] - If an error occurred, the cause of the failure.
    */
-  public peripheralDidDiscoverIncludedServicesForServiceError(
-    peripheral: CBPeripheral,
-    service: CBService,
-    error?: NSError
-  ) {
+  public peripheralDidDiscoverIncludedServicesForServiceError(peripheral: CBPeripheral, service: CBService, error?: NSError) {
     CLog(
       CLogTypes.info,
       `CBPeripheralDelegateImpl.peripheralDidDiscoverIncludedServicesForServiceError ---- peripheral: ${peripheral}, service: ${service}, error: ${error}`
@@ -81,11 +74,7 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
    * @param service [CBService] - The CBService object containing the included service.
    * @param error [NSError] - If an error occurred, the cause of the failure.
    */
-  public peripheralDidDiscoverCharacteristicsForServiceError(
-    peripheral: CBPeripheral,
-    service: CBService,
-    error?: NSError
-  ) {
+  public peripheralDidDiscoverCharacteristicsForServiceError(peripheral: CBPeripheral, service: CBService, error?: NSError) {
     CLog(
       CLogTypes.info,
       `CBPeripheralDelegateImpl.peripheralDidDiscoverCharacteristicsForServiceError ---- peripheral: ${peripheral}, service: ${service}, error: ${error}`
@@ -166,9 +155,7 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
       const descriptor = characteristic.descriptors.objectAtIndex(i);
       CLog(
         CLogTypes.info,
-        `CBPeripheralDelegateImpl.peripheralDidDiscoverDescriptorsForCharacteristicError ---- char desc UUID: ${
-          descriptor.UUID.UUIDString
-        }`
+        `CBPeripheralDelegateImpl.peripheralDidDiscoverDescriptorsForCharacteristicError ---- char desc UUID: ${descriptor.UUID.UUIDString}`
       );
     }
 
@@ -191,16 +178,9 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
    * the peripheral device notifies your app that the characteristic’s
    * value has changed.
    */
-  public peripheralDidUpdateValueForCharacteristicError(
-    peripheral: CBPeripheral,
-    characteristic: CBCharacteristic,
-    error?: NSError
-  ) {
+  public peripheralDidUpdateValueForCharacteristicError(peripheral: CBPeripheral, characteristic: CBCharacteristic, error?: NSError) {
     if (!characteristic) {
-      CLog(
-        CLogTypes.warning,
-        `CBPeripheralDelegateImpl.peripheralDidUpdateValueForCharacteristicError ---- No CBCharacteristic.`
-      );
+      CLog(CLogTypes.warning, `CBPeripheralDelegateImpl.peripheralDidUpdateValueForCharacteristicError ---- No CBCharacteristic.`);
       return;
     }
 
@@ -235,11 +215,7 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
   /**
    * Invoked when you retrieve a specified characteristic descriptor’s value.
    */
-  public peripheralDidUpdateValueForDescriptorError(
-    peripheral: CBPeripheral,
-    descriptor: CBDescriptor,
-    error?: NSError
-  ) {
+  public peripheralDidUpdateValueForDescriptorError(peripheral: CBPeripheral, descriptor: CBDescriptor, error?: NSError) {
     CLog(
       CLogTypes.info,
       `CBPeripheralDelegateImpl.peripheralDidUpdateValueForDescriptorError ---- peripheral: ${peripheral}, descriptor: ${descriptor}, error: ${error}`
@@ -249,11 +225,7 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
   /**
    * Invoked when you write data to a characteristic’s value.
    */
-  public peripheralDidWriteValueForCharacteristicError(
-    peripheral: CBPeripheral,
-    characteristic: CBCharacteristic,
-    error?: NSError
-  ) {
+  public peripheralDidWriteValueForCharacteristicError(peripheral: CBPeripheral, characteristic: CBCharacteristic, error?: NSError) {
     CLog(
       CLogTypes.info,
       `CBPeripheralDelegateImpl.peripheralDidWriteValueForCharacteristicError ---- peripheral: ${peripheral}, characteristic: ${characteristic}, error: ${error}`
@@ -263,10 +235,7 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
         characteristicUUID: characteristic.UUID.UUIDString
       });
     } else {
-      CLog(
-        CLogTypes.warning,
-        'CBPeripheralDelegateImpl.peripheralDidWriteValueForCharacteristicError ---- No _onWritePromise found!'
-      );
+      CLog(CLogTypes.warning, 'CBPeripheralDelegateImpl.peripheralDidWriteValueForCharacteristicError ---- No _onWritePromise found!');
     }
   }
 
@@ -284,10 +253,7 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
       `CBPeripheralDelegateImpl.peripheralDidUpdateNotificationStateForCharacteristicError ---- peripheral: ${peripheral}, characteristic: ${characteristic}, error: ${error}`
     );
     if (error) {
-      CLog(
-        CLogTypes.error,
-        `CBPeripheralDelegateImpl.peripheralDidUpdateNotificationStateForCharacteristicError ---- ${error}`
-      );
+      CLog(CLogTypes.error, `CBPeripheralDelegateImpl.peripheralDidUpdateNotificationStateForCharacteristicError ---- ${error}`);
     } else {
       if (characteristic.isNotifying) {
         CLog(
@@ -307,11 +273,7 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
   /**
    * IInvoked when you write data to a characteristic descriptor’s value.
    */
-  public peripheralDidWriteValueForDescriptorError(
-    peripheral: CBPeripheral,
-    descriptor: CBDescriptor,
-    error?: NSError
-  ) {
+  public peripheralDidWriteValueForDescriptorError(peripheral: CBPeripheral, descriptor: CBDescriptor, error?: NSError) {
     CLog(
       CLogTypes.info,
       `CBPeripheralDelegateImpl.peripheralDidWriteValueForDescriptorError ---- peripheral: ${peripheral}, descriptor: ${descriptor}, error: ${error}`
@@ -322,24 +284,20 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
     const props = characteristic.properties;
     return {
       // broadcast: (props & CBCharacteristicPropertyBroadcast) === CBCharacteristicPropertyBroadcast,
-      broadcast:
-        (props & CBCharacteristicProperties.PropertyBroadcast) === CBCharacteristicProperties.PropertyBroadcast,
+      broadcast: (props & CBCharacteristicProperties.PropertyBroadcast) === CBCharacteristicProperties.PropertyBroadcast,
       read: (props & CBCharacteristicProperties.PropertyRead) === CBCharacteristicProperties.PropertyRead,
-      broadcast2:
-        (props & CBCharacteristicProperties.PropertyBroadcast) === CBCharacteristicProperties.PropertyBroadcast,
+      broadcast2: (props & CBCharacteristicProperties.PropertyBroadcast) === CBCharacteristicProperties.PropertyBroadcast,
       read2: (props & CBCharacteristicProperties.PropertyRead) === CBCharacteristicProperties.PropertyRead,
       write: (props & CBCharacteristicProperties.PropertyWrite) === CBCharacteristicProperties.PropertyWrite,
       writeWithoutResponse:
-        (props & CBCharacteristicProperties.PropertyWriteWithoutResponse) ===
-        CBCharacteristicProperties.PropertyWriteWithoutResponse,
+        (props & CBCharacteristicProperties.PropertyWriteWithoutResponse) === CBCharacteristicProperties.PropertyWriteWithoutResponse,
       notify: (props & CBCharacteristicProperties.PropertyNotify) === CBCharacteristicProperties.PropertyNotify,
       indicate: (props & CBCharacteristicProperties.PropertyIndicate) === CBCharacteristicProperties.PropertyIndicate,
       authenticatedSignedWrites:
         (props & CBCharacteristicProperties.PropertyAuthenticatedSignedWrites) ===
         CBCharacteristicProperties.PropertyAuthenticatedSignedWrites,
       extendedProperties:
-        (props & CBCharacteristicProperties.PropertyExtendedProperties) ===
-        CBCharacteristicProperties.PropertyExtendedProperties,
+        (props & CBCharacteristicProperties.PropertyExtendedProperties) === CBCharacteristicProperties.PropertyExtendedProperties,
       notifyEncryptionRequired:
         (props & CBCharacteristicProperties.PropertyNotifyEncryptionRequired) ===
         CBCharacteristicProperties.PropertyNotifyEncryptionRequired,


### PR DESCRIPTION
# What is the current behaviour?
Attaching multiple notifiers does not provide any differentiation amongst data streams to the callback. Connections on Android are made with default settings, ignoring the higher-capability phones that allow for a 2M PHY selection and increased MTU size.

# What is the new behaviour?
Notify responses come with source-identifying information, allowing a callback to process the data appropriately.
Android now requests a 2M PHY if available on the device and MTU of 247 (max per BLE spec).