### PR TITLE
(fix): ios - receives all connection events without crashing on 'forg…

### DIFF
--- a/src/ios/CBCentralManagerDelegateImpl.ts
+++ b/src/ios/CBCentralManagerDelegateImpl.ts
@@ -39,21 +39,19 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
     CLog(CLogTypes.info, `----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral: ${peripheral}`);
 
     // find the peri in the array and attach the delegate to that
-    const peri = this._owner.get().findPeripheral(peripheral.identifier.UUIDString);
+    const peri = this._owner.get().findPeripheral(peripheral.identifier.UUIDString, peripheral);
     CLog(
       CLogTypes.info,
-      `----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral: cached perio: ${peri}`
+      `----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral: cached peri: ${peri}, matches incoming: ${peri ===
+        peripheral}`
     );
 
-    const cb = this._owner.get()._connectCallbacks[peripheral.identifier.UUIDString];
+    const cb = this._owner.get()._connectCallbacks[peri.identifier.UUIDString];
     const delegate = CBCentralManagerDelegateImpl.new().initWithCallback(this._owner, cb);
     CFRetain(delegate);
     peri.delegate = delegate;
 
-    CLog(
-      CLogTypes.info,
-      "----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral, let's discover service"
-    );
+    CLog(CLogTypes.info, "----- CBCentralManagerDelegateImpl centralManager:didConnectPeripheral, let's discover service");
     peri.discoverServices(null);
   }
 
@@ -67,11 +65,7 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
    * @param peripheral [CBPeripheral] - The peripheral that has been disconnected.
    * @param error? [NSError] - If an error occurred, the cause of the failure.
    */
-  public centralManagerDidDisconnectPeripheralError(
-    central: CBCentralManager,
-    peripheral: CBPeripheral,
-    error?: NSError
-  ) {
+  public centralManagerDidDisconnectPeripheralError(central: CBCentralManager, peripheral: CBPeripheral, error?: NSError) {
     // this event needs to be honored by the client as any action afterwards crashes the app
     const cb = this._owner.get()._disconnectCallbacks[peripheral.identifier.UUIDString];
     if (cb) {
@@ -94,18 +88,8 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
    * @param peripheral [CBPeripheral] - The peripheral that failed to connect.
    * @param error? [NSError] - The cause of the failure.
    */
-  public centralManagerDidFailToConnectPeripheralError(
-    central: CBCentralManager,
-    peripheral: CBPeripheral,
-    error?: NSError
-  ) {
-    CLog(
-      CLogTypes.info,
-      `CBCentralManagerDelegate.centralManagerDidFailToConnectPeripheralError ----`,
-      central,
-      peripheral,
-      error
-    );
+  public centralManagerDidFailToConnectPeripheralError(central: CBCentralManager, peripheral: CBPeripheral, error?: NSError) {
+    CLog(CLogTypes.info, `CBCentralManagerDelegate.centralManagerDidFailToConnectPeripheralError ----`, central, peripheral, error);
   }
 
   /**
@@ -126,9 +110,7 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
   ) {
     CLog(
       CLogTypes.info,
-      `CBCentralManagerDelegateImpl.centralManagerDidDiscoverPeripheralAdvertisementDataRSSI ---- ${
-        peripheral.name
-      } @ ${RSSI}`
+      `CBCentralManagerDelegateImpl.centralManagerDidDiscoverPeripheralAdvertisementDataRSSI ---- ${peripheral.name} @ ${RSSI}`
     );
     const peri = this._owner.get().findPeripheral(peripheral.identifier.UUIDString);
     if (!peri) {
@@ -139,18 +121,14 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
         if (advData.objectForKey(CBAdvertisementDataManufacturerDataKey)) {
           const manufacturerIdBuffer = this._owner
             .get()
-            .toArrayBuffer(
-              advData.objectForKey(CBAdvertisementDataManufacturerDataKey).subdataWithRange(NSMakeRange(0, 2))
-            );
+            .toArrayBuffer(advData.objectForKey(CBAdvertisementDataManufacturerDataKey).subdataWithRange(NSMakeRange(0, 2)));
           manufacturerId = new DataView(manufacturerIdBuffer, 0).getUint16(0, true);
           manufacturerData = this._owner
             .get()
             .toArrayBuffer(
               advData
                 .objectForKey(CBAdvertisementDataManufacturerDataKey)
-                .subdataWithRange(
-                  NSMakeRange(2, advData.objectForKey(CBAdvertisementDataManufacturerDataKey).length - 2)
-                )
+                .subdataWithRange(NSMakeRange(2, advData.objectForKey(CBAdvertisementDataManufacturerDataKey).length - 2))
             );
         }
 
@@ -198,9 +176,6 @@ export class CBCentralManagerDelegateImpl extends NSObject implements CBCentralM
    * @link - https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/central_manager_state_restoration_options
    */
   public centralManagerWillRestoreState(central: CBCentralManager, dict: NSDictionary<string, any>) {
-    CLog(
-      CLogTypes.info,
-      `CBCentralManagerDelegateImpl.centralManagerWillRestoreState ---- central: ${central}, dict: ${dict}`
-    );
+    CLog(CLogTypes.info, `CBCentralManagerDelegateImpl.centralManagerWillRestoreState ---- central: ${central}, dict: ${dict}`);
   }
 }

--- a/src/ios/ios_main.ts
+++ b/src/ios/ios_main.ts
@@ -218,12 +218,20 @@ export class Bluetooth extends BluetoothCommon {
     });
   }
 
-  public findPeripheral(UUID): CBPeripheral {
+  public findPeripheral(UUID, suggestedPeripheral?: CBPeripheral): CBPeripheral {
     for (let i = 0; i < this._peripheralArray.count; i++) {
       const peripheral = this._peripheralArray.objectAtIndex(i);
       if (UUID === peripheral.identifier.UUIDString) {
+        if (!!suggestedPeripheral) {
+          this._peripheralArray.replaceObjectAtIndexWithObject(i, suggestedPeripheral);
+          return suggestedPeripheral;
+        }
         return peripheral;
       }
+    }
+    if (!!suggestedPeripheral) {
+      this._peripheralArray.addObject(suggestedPeripheral);
+      return suggestedPeripheral;
     }
     return null;
   }
@@ -475,7 +483,9 @@ export class Bluetooth extends BluetoothCommon {
 
     if (!characteristic) {
       reject(
-        `Could not find characteristic with UUID ${arg.characteristicUUID} on service with UUID ${arg.serviceUUID} on peripheral with UUID ${arg.peripheralUUID}`
+        `Could not find characteristic with UUID ${arg.characteristicUUID} on service with UUID ${
+          arg.serviceUUID
+        } on peripheral with UUID ${arg.peripheralUUID}`
       );
       return null;
     }


### PR DESCRIPTION
**Bug Description**
There is a race condition bug on iOS that can cause a crash in the `centralManagerDidConnectPeripheral` callback. This is reproducible by:

- Scan for devices
- Request to connect to a device
- Scan for devices again before the connection is completed

Because the `_peripheralArray` gets thrown out on a new scan, the incoming `CBPeripheral` isn't found, and `peri` ends up as `null`. This variable is left unchecked within the callback, and then subsequently causes a crash.

**New Behaviour**
_All_ incoming `CBPeripheral` objects to this callback replace existing objects in the `_peripheralArray`. This is done with the understanding that any `CBPeripheral` received into this callback is necessarily the most correct `CBPeripheral` instance matching the `UUID` because it is now connected.
