### PR TITLE
fix: BLE Scanner not working on devices with API < 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ plugin/**/*.js
 plugin/**/*.d.ts
 
 !plugin/platforms
-/plugin/platforms/android/nativescript_bluetooth.aar
+/plugin/platforms/android/ble.aar
 package-lock.json

--- a/src/bluetooth.android.ts
+++ b/src/bluetooth.android.ts
@@ -486,7 +486,7 @@ function initLeScanCallback() {
     }
 
     /**
-     * Do not mark this one as a NativeScript class.
+     * Do not mark this one as a native class. Not doing so will allow this class to be compiled into a JavaScript pure class.
      * For a strange reason, LeScanCallback will throw errors if it's compiled into a function.
      * That is why we want it to remain a class after compile procedure.
      * Also, class will work properly if implementor is given as an argument to super class since method 'onLeScan' is originally abstract.

--- a/src/bluetooth.android.ts
+++ b/src/bluetooth.android.ts
@@ -485,12 +485,46 @@ function initLeScanCallback() {
         }
     }
 
-    @NativeClass
+    /**
+     * Do not mark this one as a NativeScript class.
+     * For a strange reason, LeScanCallback will throw errors if it's compiled into a function.
+     * That is why we want it to remain a class after compile procedure.
+     * Also, class will work properly if implementor is given as an argument to super class since method 'onLeScan' is originally abstract.
+     */
     class LeScanCallbackImpl extends android.bluetooth.BluetoothAdapter.LeScanCallback {
         onPeripheralDiscovered: (data: Peripheral) => void;
 
         constructor(private owner: WeakRef<Bluetooth>) {
-            super();
+            super(
+            {
+                onLeScan: function(device: android.bluetooth.BluetoothDevice, rssi: number, data: number[])
+                {
+                    CLog(CLogTypes.info, `TNS_LeScanCallback.onLeScan ---- device: ${device}, rssi: ${rssi}, scanRecord: ${data}`);
+
+                    let stateObject = this.owner.get().connections[device.getAddress()];
+                    if (!stateObject) {
+                        stateObject = this.owner.get().connections[device.getAddress()] = {
+                            state: 'disconnected',
+                        };
+                        const scanRecord = parseFromBytes(data);
+                        const advertismentData = new ScanAdvertisment(scanRecord);
+                        stateObject.advertismentData = advertismentData;
+                        const payload = {
+                            type: 'scanResult', // TODO or use different callback functions?
+                            UUID: device.getAddress(), // TODO consider renaming to id (and iOS as well)
+                            name: device.getName(),
+                            localName: advertismentData.localName,
+                            RSSI: rssi,
+                            state: 'disconnected',
+                            advertismentData,
+                            manufacturerId: advertismentData.manufacturerId,
+                        };
+                        CLog(CLogTypes.info, `TNS_LeScanCallback.onLeScan ---- payload: ${JSON.stringify(payload)}`);
+                        this.onPeripheralDiscovered && this.onPeripheralDiscovered(payload);
+                        this.owner.get().sendEvent(Bluetooth.device_discovered_event, payload);
+                    }
+                }
+            });
             /**
              * Callback reporting an LE device found during a device scan initiated by the startLeScan(BluetoothAdapter.LeScanCallback) function.
              * @param device [android.bluetooth.BluetoothDevice] - Identifies the remote device
@@ -498,33 +532,6 @@ function initLeScanCallback() {
              * @param scanRecord [byte[]] - The content of the advertisement record offered by the remote device.
              */
             return global.__native(this);
-        }
-
-        onLeScan(device: android.bluetooth.BluetoothDevice, rssi: number, data: number[]) {
-            CLog(CLogTypes.info, `TNS_LeScanCallback.onLeScan ---- device: ${device}, rssi: ${rssi}, scanRecord: ${data}`);
-
-            let stateObject = this.owner.get().connections[device.getAddress()];
-            if (!stateObject) {
-                stateObject = this.owner.get().connections[device.getAddress()] = {
-                    state: 'disconnected',
-                };
-                const scanRecord = parseFromBytes(data);
-                const advertismentData = new ScanAdvertisment(scanRecord);
-                stateObject.advertismentData = advertismentData;
-                const payload = {
-                    type: 'scanResult', // TODO or use different callback functions?
-                    UUID: device.getAddress(), // TODO consider renaming to id (and iOS as well)
-                    name: device.getName(),
-                    localName: advertismentData.localName,
-                    RSSI: rssi,
-                    state: 'disconnected',
-                    advertismentData,
-                    manufacturerId: advertismentData.manufacturerId,
-                };
-                CLog(CLogTypes.info, `TNS_LeScanCallback.onLeScan ---- payload: ${JSON.stringify(payload)}`);
-                this.onPeripheralDiscovered && this.onPeripheralDiscovered(payload);
-                this.owner.get().sendEvent(Bluetooth.device_discovered_event, payload);
-            }
         }
     }
     LeScanCallbackVar = LeScanCallbackImpl;


### PR DESCRIPTION
This fixes issue #165 I reported myself about plugin being broken on really old android devices.
For a strange reason, if TypeScript class LeScanCallbackImpl is compiled into a JavaScript function using "NativeClass" decorator just like all classes, it fails to actually extend native class.

My approach was to keep LeScanCallbackImpl as a class after compile procedure using the power of ES2017. Additionally, super call needs an implementor that contains 'onLeScan' method, as an argument. That is probably because 'onLeScan' was originally an abstract method in Android SDK.

**JavaScript class after compile with the power of ES2017:**
![image](https://user-images.githubusercontent.com/55595100/93085559-6a7c0600-f69e-11ea-95d7-0f05bf46ab9e.png)


Here are few device details regarding tests after fix.
**Device:** ZTE Blade A450
**OS:** Android 4.4 KitKat (API 19)
**Bluetooth enabled during test:** Yes

As a start, applications that initialized Bluetooth object stopped crashing.
Additionally, method 'startScanning' had proper and smooth functionality using the above scenario:
Inside phone's scan range, there was an HP laptop that supported BLE. Phone detected laptop with total success and displayed its UUID.

My approach looks more like a hack than a fix and I have my doubts whether it will cause any possible runtime issues in the future, but unfortunately I couldn't find any nicer working solution.

Hope this is useful in resolving this issue. :) 