### PR TITLE
Add Max MTU and 2M PHY selection

### DIFF
--- a/src/bluetooth.android.ts
+++ b/src/bluetooth.android.ts
@@ -790,13 +790,13 @@ function initBluetoothGattCallback() {
          */
         onCharacteristicChanged(gatt: android.bluetooth.BluetoothGatt, characteristic: android.bluetooth.BluetoothGattCharacteristic) {
             const device = gatt.getDevice();
-            let address: string = null;
+            let pUUID: string = null;
             if (device == null) {
                 // happens some time, why ... ?
             } else {
-                address = device.getAddress();
+              pUUID = device.getAddress();
             }
-            CLog(CLogTypes.info, `TNS_BluetoothGattCallback.onCharacteristicChanged ---- gatt: ${gatt}, characteristic: ${characteristic}, device: ${address}`);
+            CLog(CLogTypes.info, `TNS_BluetoothGattCallback.onCharacteristicChanged ---- gatt: ${gatt}, characteristic: ${characteristic}, device: ${pUUID}`);
 
             this.subDelegates.forEach((d) => {
                 if (d.onCharacteristicChanged) {
@@ -804,7 +804,7 @@ function initBluetoothGattCallback() {
                 }
             });
 
-            const stateObject = this.owner.get().connections[address];
+            const stateObject = this.owner.get().connections[pUUID];
             if (stateObject) {
                 const cUUID = uuidToString(characteristic.getUuid());
                 const sUUID = uuidToString(characteristic.getService().getUuid());
@@ -814,6 +814,7 @@ function initBluetoothGattCallback() {
                     stateObject.onNotifyCallbacks[key]({
                         android: value,
                         value: byteArrayToBuffer(value),
+                        peripheralUUID: pUUID,
                         serviceUUID: sUUID,
                         characteristicUUID: cUUID,
                     });
@@ -1730,6 +1731,8 @@ export class Bluetooth extends BluetoothCommon {
                                         resolve({
                                             android: value,
                                             value: byteArrayToBuffer(value),
+                                            peripheralUUID: pUUID,
+                                            serviceUUID: sUUID,
                                             characteristicUUID: cUUID,
                                         });
                                         clearListeners();

--- a/src/bluetooth.android.ts
+++ b/src/bluetooth.android.ts
@@ -51,6 +51,7 @@ function getAndroidSDK() {
 const JELLY_BEAN = 18;
 const LOLLIPOP = 21;
 const MARSHMALLOW = 23;
+const ANDROID10 = 29;
 
 export enum ScanMode {
     LOW_LATENCY, // = android.bluetooth.le.ScanSettings.SCAN_MODE_LOW_LATENCY,
@@ -1138,7 +1139,7 @@ export class Bluetooth extends BluetoothCommon {
         if (!hasPermission) {
             const ctx = this._getContext();
             // CLog(CLogTypes.info, 'app context', ctx);
-            const neededPermision = getAndroidSDK() < 29 ? android.Manifest.permission.ACCESS_COARSE_LOCATION : android.Manifest.permission.ACCESS_FINE_LOCATION;
+            const neededPermision = getAndroidSDK() < ANDROID10 ? android.Manifest.permission.ACCESS_COARSE_LOCATION : android.Manifest.permission.ACCESS_FINE_LOCATION;
 
             hasPermission = android.content.pm.PackageManager.PERMISSION_GRANTED === androidx.core.content.ContextCompat.checkSelfPermission(ctx, neededPermision);
             CLog(CLogTypes.info, `coarseLocationPermissionGranted ---- ${neededPermision} permission granted?`, hasPermission);
@@ -1172,7 +1173,7 @@ export class Bluetooth extends BluetoothCommon {
 
             // grab the permission dialog result
             andApp.on(AndroidApplication.activityRequestPermissionsEvent, permissionCb);
-            const neededPermision = getAndroidSDK() < 29 ? android.Manifest.permission.ACCESS_COARSE_LOCATION : android.Manifest.permission.ACCESS_FINE_LOCATION;
+            const neededPermision = getAndroidSDK() < ANDROID10 ? android.Manifest.permission.ACCESS_COARSE_LOCATION : android.Manifest.permission.ACCESS_FINE_LOCATION;
             // invoke the permission dialog
             androidx.core.app.ActivityCompat.requestPermissions(this._getActivity(), [neededPermision], ACCESS_LOCATION_PERMISSION_REQUEST_CODE);
         });

--- a/src/bluetooth.common.ts
+++ b/src/bluetooth.common.ts
@@ -498,12 +498,10 @@ export interface StartNotifyingOptions extends CRUDOptions {
 /**
  * Response object for the read function
  */
-export interface ReadResult {
+export interface ReadResult extends CRUDOptions {
     value: ArrayBuffer;
     ios?: any;
     android?: any;
-    characteristicUUID: string;
-    serviceUUID: string;
 }
 
 export interface StartAdvertisingOptions {

--- a/src/bluetooth.common.ts
+++ b/src/bluetooth.common.ts
@@ -353,6 +353,16 @@ export interface ConnectOptions {
     onDisconnected?: (data: { UUID; name: string }) => void;
 
     autoDiscoverAll?: boolean;
+
+    /**
+     * Selects 2M PHY when available (Android only)
+     */
+    auto2MegPhy?: boolean;
+
+    /**
+     * Selects maximum BLE MTU (247) (Android only)
+     */
+    autoMaxMTU?: boolean;
 }
 
 export interface AdvertismentData {
@@ -397,6 +407,8 @@ export interface Peripheral {
 
     manufacturerId?: number;
     advertismentData?: AdvertismentData;
+
+    mtu?: number;
 }
 
 /**

--- a/src/bluetooth.ios.ts
+++ b/src/bluetooth.ios.ts
@@ -98,6 +98,8 @@ import { iOSNativeHelper } from '@nativescript/core/utils/native-helper';
 export type SubPeripheralDelegate = Partial<CBPeripheralDelegate>;
 export type SubCentralManagerDelegate = Partial<CBCentralManagerDelegate>;
 
+const FIXED_IOS_MTU = 185;
+
 export interface CBPeripheralWithDelegate extends CBPeripheral {
     delegate: CBPeripheralDelegateImpl;
 }
@@ -906,6 +908,7 @@ export class Bluetooth extends BluetoothCommon {
                             localName: adv?.localName,
                             manufacturerId: adv?.manufacturerId,
                             advertismentData: adv,
+                            mtu: FIXED_IOS_MTU,
                         };
                         // delete this._advData[connectingUUID];
                         const cb = this._connectCallbacks[connectingUUID];

--- a/src/bluetooth.ios.ts
+++ b/src/bluetooth.ios.ts
@@ -232,12 +232,14 @@ export class CBPeripheralDelegateImpl extends NSObject implements CBPeripheralDe
         }
 
         if (characteristic.isNotifying) {
+            const pUUID = NSUUIDToString(peripheral.identifier);
             const cUUID = CBUUIDToString(characteristic.UUID);
             const sUUID = CBUUIDToString(characteristic.service.UUID);
             const key = sUUID + '/' + cUUID;
             if (this.onNotifyCallbacks[key]) {
                 this.onNotifyCallbacks[key]({
                     // type: 'notification',
+                    peripheralUUID: pUUID,
                     serviceUUID: sUUID,
                     characteristicUUID: cUUID,
                     ios: characteristic.value,


### PR DESCRIPTION
**Description**
This adds two optional parameters to `connect` that affect Android connections (these features are not available on iOS).

`auto2MegPhy?: boolean (default: false)`: When enabled, Android Oreo and newer will request that the 2M PHY be selected at the time of connect.

`autoMaxMTU?: boolean (default: false)`: When enabled, Android requests the maximum MTU (247) on the new connection.

In addition to the above functional features, there are also some non-breaking extensions to the response structures.

`Peripheral.mtu` is added, helping clients to `WriteWithoutResponse` data in appropriate chunk sizes.

`ReadResult.peripheralUUID` is added (via `extends CRUDOptions`) to enable clients to connect notify streams to multiple peripherals at the same time.