### PR TITLE
fix(android): 2m phy selection is now only attempted if isLe2MPhySupported is true.

### DIFF
--- a/src/bluetooth.android.ts
+++ b/src/bluetooth.android.ts
@@ -2560,7 +2560,7 @@ export class Bluetooth extends BluetoothCommon {
     }
 
     private select2MegPhy(args: { peripheralUUID: string }): Promise<void> {
-        if (getAndroidSDK() < OREO) {
+        if (getAndroidSDK() < OREO || !this.adapter.isLe2MPhySupported()) {
             return Promise.resolve();
         }
 


### PR DESCRIPTION
Just a simple check in here to help out devices that do not support the 2M Phy.