### PR TITLE
(android) Disable Notification streams

### DIFF
--- a/src/bluetooth.android.ts
+++ b/src/bluetooth.android.ts
@@ -1661,7 +1661,7 @@ export class Bluetooth extends BluetoothCommon {
                 onDisconnected: args.onDisconnected,
                 // device: gatt // TODO rename device to gatt?
             });
-            await new Promise<void>((resolve, reject) => {
+            return new Promise<void>((resolve, reject) => {
                 const clearListeners = () => {
                     this.bluetoothGattCallback.removeSubDelegate(subD);
                     this.removeDisconnectListener(onDisconnect);
@@ -1727,46 +1727,45 @@ export class Bluetooth extends BluetoothCommon {
                     // onDisconnected: args.onDisconnected,
                     device: gatt, // TODO rename device to gatt?
                 });
+            }).then(() => {
+                // This disconnects the Promise chain so these tasks can run independent of the successful connection response.
+                Promise.resolve()
+                    .then(() => !!args.autoDiscoverAll ? this.discoverAll({ peripheralUUID: pUUID }).then((result) => result?.services) : undefined)
+                    .then((services) => (!!args.auto2MegPhy ? this.select2MegPhy({ peripheralUUID: pUUID }) : Promise.resolve()).then(() => services))
+                    .then((services) => (!!args.autoMaxMTU ? this.requestMtu({ peripheralUUID: pUUID, value: MAX_MTU }) : Promise.resolve(undefined))
+                        .then((mtu?: number) => ({services, mtu})))
+                    .then(({services, mtu}) => {
+                        const stateObject = this.connections[pUUID];
+                        if (!stateObject) {
+                            return Promise.reject(
+                                new BluetoothError(BluetoothCommon.msg_peripheral_not_connected, {
+                                    method: methodName,
+                                    arguments: args,
+                                })
+                            ) as any;
+                        }
+                        stateObject.state = 'connected';
+                        const adv = stateObject.advertismentData;
+                        const dataToSend = {
+                            UUID: pUUID, // TODO consider renaming to id (and iOS as well)
+                            name: bluetoothDevice && bluetoothDevice.getName(),
+                            state: stateObject.state,
+                            services,
+                            mtu,
+                            localName: adv?.localName,
+                            manufacturerId: adv?.manufacturerId,
+                            advertismentData: adv,
+                        };
+                        if (stateObject.onConnected) {
+                            stateObject.onConnected(dataToSend);
+                            delete stateObject.onConnected;
+                        }
+                        this.sendEvent(Bluetooth.device_connected_event, dataToSend);
+                        return dataToSend;
+                    });
+
+                return Promise.resolve();
             });
-            let services, mtu;
-            if(args.autoDiscoverAll !== false) {
-                services = (await this.discoverAll({ peripheralUUID: pUUID }))?.services;
-            }
-            if (!!args.auto2MegPhy) {
-                await this.select2MegPhy({ peripheralUUID: pUUID }) ;
-            }
-            if (!!args.autoMaxMTU) {
-                mtu = await this.requestMtu({ peripheralUUID: pUUID, value: MAX_MTU }) ;
-            }
-            // get the stateObject again to see if we got disconnected
-            stateObject = this.connections[pUUID];
-            if (!stateObject) {
-                return Promise.reject(
-                    new BluetoothError(BluetoothCommon.msg_peripheral_not_connected, {
-                        method: methodName,
-                        arguments: args,
-                    })
-                ) as any;
-            }
-            stateObject.state = 'connected';
-            const adv = stateObject.advertismentData;
-            const dataToSend = {
-                UUID: pUUID, // TODO consider renaming to id (and iOS as well)
-                name: bluetoothDevice && bluetoothDevice.getName(),
-                state: stateObject.state,
-                services,
-                mtu,
-                nativeDevice: bluetoothDevice,
-                localName: adv?.localName,
-                manufacturerId: adv?.manufacturerId,
-                advertismentData: adv,
-            };
-            if (stateObject.onConnected) {
-                stateObject.onConnected(dataToSend);
-                delete stateObject.onConnected;
-            }
-            this.sendEvent(Bluetooth.device_connected_event, dataToSend);
-            return dataToSend;
         }
     }
 
@@ -1801,7 +1800,9 @@ export class Bluetooth extends BluetoothCommon {
     }
 
     private addToGatQueue(p: () => Promise<any>) {
-        return this.gattQueue.add(p);
+        // TODO: Restore the gattQueue, but optionally.
+        // return this.gattQueue.add(p);
+        return p();
     }
 
     private addToQueue(args: WrapperOptions, runner: (wrapper: WrapperResult) => any) {

--- a/src/bluetooth.ios.ts
+++ b/src/bluetooth.ios.ts
@@ -770,6 +770,7 @@ export class Bluetooth extends BluetoothCommon {
             if (Trace.isEnabled()) {
                 CLog(CLogTypes.info, 'isBluetoothEnabled', 'central manager not ready, waiting for it to start');
             }
+            this.ensureCentralManager();
             return new Promise<boolean>((resolve) => {
                 this.once(BluetoothCommon.bluetooth_status_event, ()=> {
                     resolve(this._isEnabled());

--- a/src/bluetooth.ios.ts
+++ b/src/bluetooth.ios.ts
@@ -942,7 +942,7 @@ export class Bluetooth extends BluetoothCommon {
                     arguments: args,
                 });
             } else {
-                await new Promise<void>((resolve, reject) => {
+                return new Promise<void>((resolve, reject) => {
                     const subD = {
                         centralManagerDidConnectPeripheral: (central: CBCentralManager, peripheral: CBPeripheral) => {
                             const UUID = NSUUIDToString(peripheral.identifier);
@@ -974,34 +974,39 @@ export class Bluetooth extends BluetoothCommon {
                         CLog(CLogTypes.info, methodName, '----about to connect:', connectingUUID, this._centralDelegate, this._centralManager);
                     }
                     this.centralManager.connectPeripheralOptions(peripheral, null);
+                }).then(() =>  {
+                    // This disconnects the Promise chain so these tasks can run independent of the successful connection response.
+                    Promise.resolve()
+                        .then(() => {
+                            if (args.autoDiscoverAll !== false) {
+                                return this.discoverAll({ peripheralUUID: connectingUUID });
+                            }
+                            return undefined;
+                        })
+                        .then((result) => {
+                            const adv = this._advData[connectingUUID];
+                            const dataToSend = {
+                                UUID: connectingUUID,
+                                name: peripheral.name,
+                                state: this._getState(peripheral.state),
+                                services: result?.services,
+                                localName: adv?.localName,
+                                manufacturerId: adv?.manufacturerId,
+                                advertismentData: adv,
+                                mtu: FIXED_IOS_MTU,
+                            };
+                            // delete this._advData[connectingUUID];
+                            const cb = this._connectCallbacks[connectingUUID];
+                            if (cb) {
+                                cb(dataToSend);
+                                delete this._connectCallbacks[connectingUUID];
+                            }
+                            this.sendEvent(Bluetooth.device_connected_event, dataToSend);
+                            return dataToSend;
+                        });
+
+                    return Promise.resolve();
                 });
-                let services, mtu = FIXED_IOS_MTU;
-                if (args.autoDiscoverAll !== false) {
-                    services = (await this.discoverAll({ peripheralUUID: connectingUUID }))?.services;
-                }
-                if (!!args.autoMaxMTU) {
-                    mtu = await this.requestMtu({ peripheralUUID: connectingUUID, value: FIXED_IOS_MTU }) ;
-                }
-                const adv = this._advData[connectingUUID];
-                const dataToSend = {
-                    UUID: connectingUUID,
-                    name: peripheral.name,
-                    state: this._getState(peripheral.state),
-                    services,
-                    nativeDevice: peripheral,
-                    localName: adv?.localName,
-                    manufacturerId: adv?.manufacturerId,
-                    advertismentData: adv,
-                    mtu,
-                };
-                // delete this._advData[connectingUUID];
-                const cb = this._connectCallbacks[connectingUUID];
-                if (cb) {
-                    cb(dataToSend);
-                    delete this._connectCallbacks[connectingUUID];
-                }
-                this.sendEvent(Bluetooth.device_connected_event, dataToSend);
-                return dataToSend;
             }
         } catch (ex) {
             if (Trace.isEnabled()) {
@@ -1042,7 +1047,8 @@ export class Bluetooth extends BluetoothCommon {
             } else {
                 // no need to send an error when already disconnected, but it's wise to check it
                 if (peripheral.state !== CBPeripheralState.Disconnected) {
-                    return new Promise<void>((resolve, reject) => {
+                    // This disconnects the Promise chain so these tasks can run independent of the successful connection response.
+                    (new Promise<void>((resolve, reject) => {
                         const subD = {
                             centralManagerDidDisconnectPeripheralError: (central: CBCentralManager, peripheral: CBPeripheral, error?: NSError) => {
                                 const UUID = NSUUIDToString(peripheral.identifier);
@@ -1066,6 +1072,10 @@ export class Bluetooth extends BluetoothCommon {
                             CLog(CLogTypes.info, methodName, '---- Disconnecting peripheral with UUID', pUUID);
                         }
                         this.centralManager.cancelPeripheralConnection(peripheral);
+                    })).catch((ex) => {
+                        if (Trace.isEnabled()) {
+                            CLog(CLogTypes.error, methodName, '---- error:', ex);
+                        }
                     });
                 }
                 return Promise.resolve();


### PR DESCRIPTION
Notification streams on Android were not being stopped as requested. This now correctly assigns "DISABLE" to the characteristic's descriptor, as the opposite operation as is seen in the `startNotifying` implementation.

Included in this PR is also a correction to the Promise handling, allowing the affected functions to correctly be included in a Promise chain. `addToGatQueue` queue functionality is disabled. The usage of a queue here within the library should be optional at most; never required.

I have confirmed correct execution within my BLE-heavy app, using multiple notification streams in parallel, many read/writes, and complex command queuing.