### PR TITLE
fix(ios): Ensure the Central Manager is created prior to waiting for the bluetooth_status_event.

### DIFF
--- a/src/bluetooth.ios.ts
+++ b/src/bluetooth.ios.ts
@@ -770,6 +770,7 @@ export class Bluetooth extends BluetoothCommon {
             if (Trace.isEnabled()) {
                 CLog(CLogTypes.info, 'isBluetoothEnabled', 'central manager not ready, waiting for it to start');
             }
+            this.ensureCentralManager();
             return new Promise<boolean>((resolve) => {
                 this.once(BluetoothCommon.bluetooth_status_event, ()=> {
                     resolve(this._isEnabled());


### PR DESCRIPTION
When the Central Manager is already created, this is effectively a no-op, but the inclusion here ensures that it will be created prior to waiting for the `bluetooth_status_event`.