### PR TITLE
feat(android): corrects Promise handling and introduces the ability to disable the plugin queue.

### DIFF
--- a/src/bluetooth.common.ts
+++ b/src/bluetooth.common.ts
@@ -75,7 +75,7 @@ export function prepareArgs(target: Object, propertyKey: string, descriptor: Typ
 }
 
 export interface BluetoothOptions {
-  restoreIdentifier: string;
+  restoreIdentifier: string | null;
   showPowerAlertPopup: boolean;
   disableAndroidQueue: boolean;
 }

--- a/src/bluetooth.common.ts
+++ b/src/bluetooth.common.ts
@@ -74,6 +74,12 @@ export function prepareArgs(target: Object, propertyKey: string, descriptor: Typ
     return descriptor;
 }
 
+export interface BluetoothOptions {
+  restoreIdentifier: string;
+  showPowerAlertPopup: boolean;
+  disableAndroidQueue: boolean;
+}
+
 export abstract class BluetoothCommon extends Observable {
     /*
      * error messages

--- a/src/bluetooth.d.ts
+++ b/src/bluetooth.d.ts
@@ -1,6 +1,7 @@
 import {
     AdvertismentData,
     BluetoothCommon,
+    BluetoothOptions,
     CallbackType,
     Characteristic,
     ConnectOptions,
@@ -56,7 +57,7 @@ export class Bluetooth extends BluetoothCommon {
     /**
      * restoreIdentifier is optional and only used on iOS
      */
-    constructor(restoreIndentifier?: string);
+    constructor(restoreIndentifierOrOptions?: string | Partial<BluetoothOptions>);
 
     /**
      * everything needed to clear on app close

--- a/src/bluetooth.ios.ts
+++ b/src/bluetooth.ios.ts
@@ -17,6 +17,7 @@ import {
     WriteOptions,
     bluetoothEnabled,
     prepareArgs,
+    BluetoothOptions,
 } from './bluetooth.common';
 import { Trace } from '@nativescript/core';
 
@@ -697,10 +698,19 @@ export class Bluetooth extends BluetoothCommon {
         return this._centralManager;
     }
 
-    constructor(private restoreIdentifier: string = 'ns_bluetooth', private showPowerAlertPopup = false) {
+    private restoreIdentifier: string;
+
+    constructor(restoreIdentifierOrOptions: string | Partial<BluetoothOptions> = 'ns_bluetooth', private showPowerAlertPopup = false) {
         super();
+        if (typeof restoreIdentifierOrOptions === 'string') {
+          this.restoreIdentifier = restoreIdentifierOrOptions;
+        } else if (!!restoreIdentifierOrOptions) {
+          this.restoreIdentifier = restoreIdentifierOrOptions.restoreIdentifier || 'ns_bluetooth';
+          this.showPowerAlertPopup = !!restoreIdentifierOrOptions.showPowerAlertPopup;
+        }
+
         if (Trace.isEnabled()) {
-            CLog(CLogTypes.info, 'Creating Bluetooth instance', restoreIdentifier);
+            CLog(CLogTypes.info, 'Creating Bluetooth instance', this.restoreIdentifier);
         }
     }
 
@@ -942,7 +952,7 @@ export class Bluetooth extends BluetoothCommon {
                     arguments: args,
                 });
             } else {
-                await new Promise<void>((resolve, reject) => {
+                return new Promise<void>((resolve, reject) => {
                     const subD = {
                         centralManagerDidConnectPeripheral: (central: CBCentralManager, peripheral: CBPeripheral) => {
                             const UUID = NSUUIDToString(peripheral.identifier);
@@ -974,34 +984,39 @@ export class Bluetooth extends BluetoothCommon {
                         CLog(CLogTypes.info, methodName, '----about to connect:', connectingUUID, this._centralDelegate, this._centralManager);
                     }
                     this.centralManager.connectPeripheralOptions(peripheral, null);
+                }).then(() =>  {
+                    // This disconnects the Promise chain so these tasks can run independent of the successful connection response.
+                    Promise.resolve()
+                        .then(() => {
+                            if (args.autoDiscoverAll !== false) {
+                                return this.discoverAll({ peripheralUUID: connectingUUID });
+                            }
+                            return undefined;
+                        })
+                        .then((result) => {
+                            const adv = this._advData[connectingUUID];
+                            const dataToSend = {
+                                UUID: connectingUUID,
+                                name: peripheral.name,
+                                state: this._getState(peripheral.state),
+                                services: result?.services,
+                                localName: adv?.localName,
+                                manufacturerId: adv?.manufacturerId,
+                                advertismentData: adv,
+                                mtu: FIXED_IOS_MTU,
+                            };
+                            // delete this._advData[connectingUUID];
+                            const cb = this._connectCallbacks[connectingUUID];
+                            if (cb) {
+                                cb(dataToSend);
+                                delete this._connectCallbacks[connectingUUID];
+                            }
+                            this.sendEvent(Bluetooth.device_connected_event, dataToSend);
+                            return dataToSend;
+                        });
+
+                    return Promise.resolve();
                 });
-                let services, mtu = FIXED_IOS_MTU;
-                if (args.autoDiscoverAll !== false) {
-                    services = (await this.discoverAll({ peripheralUUID: connectingUUID }))?.services;
-                }
-                if (!!args.autoMaxMTU) {
-                    mtu = await this.requestMtu({ peripheralUUID: connectingUUID, value: FIXED_IOS_MTU }) ;
-                }
-                const adv = this._advData[connectingUUID];
-                const dataToSend = {
-                    UUID: connectingUUID,
-                    name: peripheral.name,
-                    state: this._getState(peripheral.state),
-                    services,
-                    nativeDevice: peripheral,
-                    localName: adv?.localName,
-                    manufacturerId: adv?.manufacturerId,
-                    advertismentData: adv,
-                    mtu,
-                };
-                // delete this._advData[connectingUUID];
-                const cb = this._connectCallbacks[connectingUUID];
-                if (cb) {
-                    cb(dataToSend);
-                    delete this._connectCallbacks[connectingUUID];
-                }
-                this.sendEvent(Bluetooth.device_connected_event, dataToSend);
-                return dataToSend;
             }
         } catch (ex) {
             if (Trace.isEnabled()) {
@@ -1042,7 +1057,8 @@ export class Bluetooth extends BluetoothCommon {
             } else {
                 // no need to send an error when already disconnected, but it's wise to check it
                 if (peripheral.state !== CBPeripheralState.Disconnected) {
-                    return new Promise<void>((resolve, reject) => {
+                    // This disconnects the Promise chain so these tasks can run independent of the successful connection response.
+                    (new Promise<void>((resolve, reject) => {
                         const subD = {
                             centralManagerDidDisconnectPeripheralError: (central: CBCentralManager, peripheral: CBPeripheral, error?: NSError) => {
                                 const UUID = NSUUIDToString(peripheral.identifier);
@@ -1066,6 +1082,10 @@ export class Bluetooth extends BluetoothCommon {
                             CLog(CLogTypes.info, methodName, '---- Disconnecting peripheral with UUID', pUUID);
                         }
                         this.centralManager.cancelPeripheralConnection(peripheral);
+                    })).catch((ex) => {
+                        if (Trace.isEnabled()) {
+                            CLog(CLogTypes.error, methodName, '---- error:', ex);
+                        }
                     });
                 }
                 return Promise.resolve();

--- a/src/bluetooth.ios.ts
+++ b/src/bluetooth.ios.ts
@@ -700,13 +700,17 @@ export class Bluetooth extends BluetoothCommon {
 
     private restoreIdentifier: string;
 
-    constructor(restoreIdentifierOrOptions: string | Partial<BluetoothOptions> = 'ns_bluetooth', private showPowerAlertPopup = false) {
+    constructor(restoreIdentifierOrOptions: string | Partial<BluetoothOptions> | null = 'ns_bluetooth', private showPowerAlertPopup = false) {
         super();
-        if (typeof restoreIdentifierOrOptions === 'string') {
-          this.restoreIdentifier = restoreIdentifierOrOptions;
-        } else if (!!restoreIdentifierOrOptions) {
-          this.restoreIdentifier = restoreIdentifierOrOptions.restoreIdentifier || 'ns_bluetooth';
+        if (typeof restoreIdentifierOrOptions === 'object') {
+          if (restoreIdentifierOrOptions.restoreIdentifier === undefined) {
+            this.restoreIdentifier = 'ns_bluetooth';
+          } else {
+            this.restoreIdentifier = restoreIdentifierOrOptions.restoreIdentifier;
+          }
           this.showPowerAlertPopup = !!restoreIdentifierOrOptions.showPowerAlertPopup;
+        } else {
+          this.restoreIdentifier = restoreIdentifierOrOptions;
         }
 
         if (Trace.isEnabled()) {


### PR DESCRIPTION
The parameters to the `Bluetooth` constructor have been changed into an object so they can be named. This allows the plugin's queue on Android to be disabled, requiring the calling app to manage its own queue.