### PR TITLE
feat: `avoidDuplicates` option on `startScanning` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ A few of the optional params require a bit of explanation:
 #### seconds
 Scanning for peripherals drains the battery quickly, so you better not scan any longer than necessary. If a peripheral is in range and not engaged in another connection it usually pops up in under a second. If you don't pass in a number of seconds you will need to manually call `stopScanning`.
 
+#### avoidDuplicates
+Set this to true if you don't want duplicates with the same serviceUUID reported in "onDiscovered" callback.
+If true, only the first discovered peripheral with the same serviceUUID will be reported.
+
 #### skipPermissionCheck
 Set this to true if you don't want the plugin to check (and request) the required Bluetooth permissions.
 Particularly useful if you're running this function on a non-UI thread (ie. a Worker).

--- a/src/bluetooth.common.ts
+++ b/src/bluetooth.common.ts
@@ -221,6 +221,12 @@ export interface StartScanningOptions {
     seconds?: number;
 
     /**
+     * Avoid duplicates with the same serviceUUID in "onDiscovered" callback.
+     * If true, only the first discovered peripheral with the same serviceUUID will be reported.
+     */
+    avoidDuplicates?: boolean;
+
+    /**
      * This callback is invoked when a peripheral is found.
      */
     onDiscovered?: (data: Peripheral) => void;

--- a/src/bluetooth.ios.ts
+++ b/src/bluetooth.ios.ts
@@ -823,8 +823,13 @@ export class Bluetooth extends BluetoothCommon {
                     CLog(CLogTypes.info, methodName, '---- services:', services);
                 }
 
+                const options: NSMutableDictionary<any, any> = new (NSMutableDictionary as any)();
+                if (!args.avoidDuplicates) {
+                    options.setObjectForKey(true, CBCentralManagerScanOptionAllowDuplicatesKey);
+                }
+
                 // TODO: check on the services as any casting
-                this.centralManager.scanForPeripheralsWithServicesOptions(services as any, null);
+                this.centralManager.scanForPeripheralsWithServicesOptions(services as any, options);
                 if (this.scanningReferTimer) {
                     clearTimeout(this.scanningReferTimer.timer);
                     this.scanningReferTimer.resolve();


### PR DESCRIPTION
I finally chose to name the parameter `avoidDuplicates` instead of `allowDuplicates` so it is `false` by default. It simplifies the code as we don't have to set a default value if the parameter is `undefined`. Plus, it makes all boolean parameters of `startScanning` false by default.

Tested on both Android & iOS with and without `avoidDuplicates`.

Closes #206