### PR TITLE
fix_ios_serviceUUID_assigned_numbers

### DIFF
--- a/src/bluetooth.common.ts
+++ b/src/bluetooth.common.ts
@@ -52,7 +52,13 @@ export function bluetoothEnabled(target: Object, propertyKey: string, descriptor
     return descriptor;
 }
 
-const pattern = /0000(.{4})-0000-1000-8000-00805f9b34fb/;
+// BT assigned-numbers: https://www.bluetooth.com/specifications/assigned-numbers/
+const patternBtAssignedNumbers = /0000(.{4})-0000-1000-8000-00805f9b34fb/i;
+export function shortenUuidIfAssignedNumber(uuid: string) {
+    const matcher = uuid.toLowerCase().match(patternBtAssignedNumbers);
+    return (matcher && matcher.length > 0 ? matcher[1] : uuid);
+}
+
 export function prepareArgs(target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>) {
     const originalMethod = descriptor.value as Function; // save a reference to the original method
 
@@ -65,13 +71,9 @@ export function prepareArgs(target: Object, propertyKey: string, descriptor: Typ
                 const value = paramsToCheck[k];
                 if (value) {
                     if (Array.isArray(value)) {
-                        paramsToCheck[k] = paramsToCheck[k].map(v=>{
-                            const matcher = (v as string).match(pattern);
-                            return  (matcher && matcher.length > 0 ? matcher[1] : v).toLowerCase();
-                        });
+                        paramsToCheck[k] = paramsToCheck[k].map(v => shortenUuidIfAssignedNumber(v));
                     } else {
-                        const matcher = (paramsToCheck[k] as string).match(pattern);
-                        paramsToCheck[k] = (matcher && matcher.length > 0 ? matcher[1] : paramsToCheck[k]).toLowerCase();
+                        paramsToCheck[k] = shortenUuidIfAssignedNumber(paramsToCheck[k] ?? '');
                     }
                 }
             });
@@ -531,7 +533,7 @@ export interface DiscoverCharacteristicsOptions extends DiscoverOptions {
 }
 
 // tslint:disable-next-line:no-empty-interface
-export interface StopNotifyingOptions extends CRUDOptions {}
+export interface StopNotifyingOptions extends CRUDOptions { }
 
 export interface StartNotifyingOptions extends CRUDOptions {
     onNotify: (data: ReadResult) => void;

--- a/src/bluetooth.ios.ts
+++ b/src/bluetooth.ios.ts
@@ -20,6 +20,7 @@ import {
     WriteOptions,
     bluetoothEnabled,
     prepareArgs,
+    shortenUuidIfAssignedNumber,
 } from './bluetooth.common';
 import { Trace } from '@nativescript/core';
 
@@ -1640,8 +1641,12 @@ export class Bluetooth extends BluetoothCommon {
             const subD = {
                 peripheralDidDiscoverCharacteristicsForServiceError: (peripheral: CBPeripheral, service: CBService, error?: NSError) => {
                     const UUID = NSUUIDToString(peripheral.identifier);
-                    const sUUID = CBUUIDToString(service.UUID);
-                    if (UUID === pUUID && sUUID === args.serviceUUID) {
+                    const sUuidLong = CBUUIDToString(service.UUID);
+                    const sUuidShort = shortenUuidIfAssignedNumber(sUuidLong);
+                    if (Trace.isEnabled()) {
+                        CLog(CLogTypes.info, `discoverCharacteristics [UUID]: ${UUID}, [pUUID]: ${pUUID}, [args.serviceUUID]: ${args.serviceUUID}, [sUuidLong]: ${sUuidLong}, [sUuidShort]: ${sUuidShort}`);
+                    }
+                    if (UUID === pUUID && (sUuidLong === args.serviceUUID || sUuidShort === args.serviceUUID)) {
                         if (error) {
                             reject(
                                 new BluetoothError(error.localizedDescription, {


### PR DESCRIPTION
Fix to handle Short UUID and Long UUID... In case the hardware platform returns a Long UUID when we were expecting a Short UUID.  

Note Short UUIDs are usually expected when the Service UUID is an Bluetooth Assigned Name...

For some reason (whether due to arduino BLE programming; or, iPhone version) the Assigne Name service UUID was being presented in Long UUID format, whereas BLE plugin was assuming it should be Short UUID. 

This change will cause BLE to support Assigned Names as Long or Short UUIDs (regardless of how the platform returns them)