### PR TITLE
fix(android): Device disconnect type error

### DIFF
--- a/src/ble/index.android.ts
+++ b/src/ble/index.android.ts
@@ -1799,7 +1799,7 @@ export class Bluetooth extends BluetoothCommon {
         if (Trace.isEnabled()) {
             CLog(CLogTypes.info, methodName, '---- connection:', pUUID);
         }
-        if (!connection) {
+        if (!connection || connection.state !== 'connected') {
             throw new BluetoothError(BluetoothCommon.msg_peripheral_not_connected, {
                 method: methodName,
                 arguments: args


### PR DESCRIPTION
On android, there is a case when a method `disconnect` call throws a `TypeError` when device is still connecting.
That is because even though connection is cached, there's a chance that device is not set yet.
This PR adds a check to throw the proper bluetooth error instead.